### PR TITLE
Fixes Data Downloader

### DIFF
--- a/QuiverCongressDataPoint.cs
+++ b/QuiverCongressDataPoint.cs
@@ -85,7 +85,6 @@ namespace QuantConnect.DataSource
         /// <summary>
         /// Creates a new instance of QuiverCongressDataPoint
         /// </summary>
-        /// <param name="csvLine">CSV line</param>
         public QuiverCongressDataPoint()
         {
         }

--- a/QuiverQuantCongressUniverse.cs
+++ b/QuiverQuantCongressUniverse.cs
@@ -151,7 +151,7 @@ namespace QuantConnect.DataSource
         /// <returns>The <see cref="T:NodaTime.DateTimeZone" /> of this data type</returns>
         public override DateTimeZone DataTimeZone()
         {
-            return TimeZones.Chicago;
+            return TimeZones.Utc;
         }
     }
 }


### PR DESCRIPTION
- Use a new endpoint to get bulk data (improve processing: 10 second execution time)
- Aggregate trades with the same `Symbol`, `TransationData`, and `Direction`. The raw data has repeated trades that are considered bad data. We aggregate these trades to avoid confusion.
- Fix timezone of Universe Class: it should make the single asset case.