### PR TITLE
Use the New Endpoint `bulk/congresstrading?version=v2`

### DIFF
--- a/DataProcessing/QuiverCongressDataDownloader.cs
+++ b/DataProcessing/QuiverCongressDataDownloader.cs
@@ -22,7 +22,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -33,7 +33,6 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Util;
-using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.DataProcessing
 {
@@ -93,7 +92,7 @@ namespace QuantConnect.DataProcessing
 
             try
             {
-                var rawCongressData = HttpRequester($"bulk/congresstrading").SynchronouslyAwaitTaskResult();
+                var rawCongressData = HttpRequester($"bulk/congresstrading?version=v2").SynchronouslyAwaitTaskResult();
                 if (string.IsNullOrWhiteSpace(rawCongressData))
                 {
                     Log.Trace($@"QuiverCongressDataDownloader.Run(): Received no data - {rawCongressData}");
@@ -102,7 +101,7 @@ namespace QuantConnect.DataProcessing
                 Log.Trace($@"QuiverCongressDataDownloader.Run(): Received data");
 
                 var congressTradesByDate = JsonConvert
-                    .DeserializeObject<List<RawQuiverCongressDataPoint>>(rawCongressData, _jsonSerializerSettings)
+                    .DeserializeObject<List<RawQuiverCongressDataPoint>>(rawCongressData, _jsonSerializerSettings)!
                     .Where(x =>
                     {
                         // We don't have enough information to disambiguate whether this transaction,
@@ -110,7 +109,8 @@ namespace QuantConnect.DataProcessing
                         // Also, ReportDate might be null, but we use it for setting the EndTime
                         // of the QuiverCongress type. So if it doesn't exist, we don't know
                         // when the data was made available to us.
-                        if (x.Transaction == OrderDirection.Hold || x.ReportDate == null || x.ReportDate > today)
+                        var isStock = !string.IsNullOrWhiteSpace(x.TickerType) || x.TickerType != "Stock" || x.TickerType != "ST";
+                        if (x.Transaction == OrderDirection.Hold || x.ReportDate == null || x.ReportDate > today || !isStock)
                         {
                             return false;
                         }
@@ -123,12 +123,11 @@ namespace QuantConnect.DataProcessing
                         // A Congressperson can make the same trade more than once per day
                         // To avoid confusion, we will group the same trades and sum their amount
                         var values = kvp.ToList();
-                        var duplicates = kvp.GroupBy(x => x.ToString()).Where(x => x.Count() > 1);
+                        var duplicates = kvp.GroupBy(x => $"{x.Ticker},{x}").Where(x => x.Count() > 1);
                         foreach (var duplicate in duplicates)
                         {
                             var trade = duplicate.FirstOrDefault();
-                            trade.Amount = values.Where(x => duplicate.Key == x.ToString()).Sum(x => x.Amount);
-                            values.RemoveAll(x => duplicate.Key == x.ToString());
+                            values.RemoveAll(x => duplicate.Key == $"{x.Ticker},{x}");
                             values.Add(trade);
                         }
                         return values;
@@ -159,12 +158,7 @@ namespace QuantConnect.DataProcessing
                             congressTradesByTicker.Add(ticker, new List<string>());
                         }
 
-                        var curRow = string.Join(",",
-                            $"{congressTrade.TransactionDate.ToStringInvariant("yyyyMMdd")}",
-                            $"{congressTrade.Representative.Trim()}",
-                            $"{congressTrade.Transaction}",
-                            $"{congressTrade.Amount.ToStringInvariant()}",
-                            $"{congressTrade.House}");
+                        var curRow = congressTrade.ToString();
 
                         congressTradesByTicker[ticker].Add($"{processDate:yyyyMMdd},{curRow}");
 
@@ -217,49 +211,46 @@ namespace QuantConnect.DataProcessing
         /// <exception cref="Exception">Failed to get data after exceeding retries</exception>
         private async Task<string> HttpRequester(string url)
         {
-            url = Uri.EscapeDataString(url);
             var baseUrl = "https://api.quiverquant.com/beta/";
 
             for (var retries = 1; retries <= MaxRetries; retries++)
             {
                 try
                 {
-                    using (var client = new HttpClient())
+                    using var client = new HttpClient();
+                    client.BaseAddress = new Uri(baseUrl);
+                    client.DefaultRequestHeaders.Clear();
+
+                    // You must supply your API key in the HTTP header,
+                    // otherwise you will receive a 403 Forbidden response
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", _clientKey);
+
+                    // Responses are in JSON: you need to specify the HTTP header Accept: application/json
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                    // Makes sure we don't overrun Quiver rate limits accidentally
+                    _indexGate.WaitToProceed();
+
+                    var response = await client.GetAsync(url);
+                    if (response.StatusCode == HttpStatusCode.NotFound)
                     {
-                        client.BaseAddress = new Uri(baseUrl);
-                        client.DefaultRequestHeaders.Clear();
-
-                        // You must supply your API key in the HTTP header,
-                        // otherwise you will receive a 403 Forbidden response
-                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", _clientKey);
-
-                        // Responses are in JSON: you need to specify the HTTP header Accept: application/json
-                        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-
-                        // Makes sure we don't overrun Quiver rate limits accidentally
-                        _indexGate.WaitToProceed();
-
-                        var response = await client.GetAsync(url);
-                        if (response.StatusCode == HttpStatusCode.NotFound)
-                        {
-                            Log.Error($"QuiverCongressDataDownloader.HttpRequester(): Files not found at url: {url}");
-                            response.DisposeSafely();
-                            return string.Empty;
-                        }
-
-                        if (response.StatusCode == HttpStatusCode.Unauthorized)
-                        {
-                            var finalRequestUri = response.RequestMessage.RequestUri; // contains the final location after following the redirect.
-                            response = client.GetAsync(finalRequestUri).Result; // Reissue the request. The DefaultRequestHeaders configured on the client will be used, so we don't have to set them again.
-                        }
-
-                        response.EnsureSuccessStatusCode();
-
-                        var result =  await response.Content.ReadAsStringAsync();
+                        Log.Error($"QuiverCongressDataDownloader.HttpRequester(): Files not found at url: {url}");
                         response.DisposeSafely();
-
-                        return result;
+                        return string.Empty;
                     }
+
+                    if (response.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        var finalRequestUri = response.RequestMessage.RequestUri; // contains the final location after following the redirect.
+                        response = client.GetAsync(finalRequestUri).Result; // Reissue the request. The DefaultRequestHeaders configured on the client will be used, so we don't have to set them again.
+                    }
+
+                    response.EnsureSuccessStatusCode();
+
+                    var result = await response.Content.ReadAsStringAsync();
+                    response.DisposeSafely();
+
+                    return result;
                 }
                 catch (Exception e)
                 {
@@ -270,7 +261,7 @@ namespace QuantConnect.DataProcessing
 
             throw new Exception($"Request for {baseUrl}{url} failed with no more retries remaining (retry {MaxRetries}/{MaxRetries})");
         }
-
+        
         /// <summary>
         /// Saves contents to disk, deleting existing zip files
         /// </summary>
@@ -301,17 +292,54 @@ namespace QuantConnect.DataProcessing
             public string Ticker { get; set; }
 
             /// <summary>
+            /// The security type
+            /// </summary>
+            [JsonProperty(PropertyName = "TickerType")]
+            public string TickerType { get; set; }
+
+            /// <summary>
+            /// The trade size range
+            /// </summary>
+            [JsonProperty(PropertyName = "Trade_Size_USD")]
+            public string TradeSizeRange { get; set; }
+
+            /// <summary>
             /// Formats a string with the Raw Quiver Congress information.
             /// This information does not include the amount, since we will use this
             /// representation to group the trades of the same day, person and direction 
             /// </summary>
             public override string ToString()
             {
-                return Invariant($"{Ticker}({ReportDate}) :: ") +
-                       Invariant($"Transaction Date: {TransactionDate} ") +
-                       Invariant($"Representative: {Representative} ") +
-                       Invariant($"House: {House} ") +
-                       Invariant($"Transaction: {Transaction} ");
+                var isSingle = true;
+                var tradeSizeRange = new StringBuilder();
+                foreach (var c in TradeSizeRange.AsSpan())
+                {
+                    if (char.IsDigit(c))
+                    {
+                        tradeSizeRange.Append(c);
+                    }
+                    else if (c == '-')
+                    {
+                        isSingle = false;
+                        tradeSizeRange.Append(',');
+                    }
+                }
+
+                if (isSingle)
+                {
+                    tradeSizeRange.Append(',');
+                }
+
+                return string.Join(",",
+                        $"{TransactionDate.ToStringInvariant("yyyyMMdd")}",
+                        $"{Representative.Trim().Replace(",", ";")}",
+                        $"{Transaction}",
+                        $"{tradeSizeRange}",
+                        $"{House}",
+                        $"{Party}",
+                        $"{District?.Trim()}",
+                        $"{State.Trim()}"
+                    );
             }
         }
 

--- a/DataProcessing/QuiverCongressDataDownloader.cs
+++ b/DataProcessing/QuiverCongressDataDownloader.cs
@@ -109,8 +109,9 @@ namespace QuantConnect.DataProcessing
                         // Also, ReportDate might be null, but we use it for setting the EndTime
                         // of the QuiverCongress type. So if it doesn't exist, we don't know
                         // when the data was made available to us.
-                        var isStock = !string.IsNullOrWhiteSpace(x.TickerType) || x.TickerType != "Stock" || x.TickerType != "ST";
-                        if (x.Transaction == OrderDirection.Hold || x.ReportDate == null || x.ReportDate > today || !isStock)
+                        // Stock are represented by null/empty TickerType or "Stock" or "ST" values
+                        var isNotStock = !string.IsNullOrWhiteSpace(x.TickerType) && x.TickerType is not ("Stock" or "ST");
+                        if (x.Transaction == OrderDirection.Hold || x.ReportDate == null || x.ReportDate > today || isNotStock)
                         {
                             return false;
                         }
@@ -261,7 +262,7 @@ namespace QuantConnect.DataProcessing
 
             throw new Exception($"Request for {baseUrl}{url} failed with no more retries remaining (retry {MaxRetries}/{MaxRetries})");
         }
-        
+
         /// <summary>
         /// Saves contents to disk, deleting existing zip files
         /// </summary>

--- a/Party.cs
+++ b/Party.cs
@@ -18,20 +18,26 @@ using System.Runtime.Serialization;
 namespace QuantConnect.DataSource
 {
     /// <summary>
-    /// United States of America Legislative Branch House of Congress
+    /// Political Parties of the United States of America
     /// </summary>
-    public enum Congress
+    public enum Party
     {
         /// <summary>
-        /// The United States Senate
+        /// Not affiliated with any political party.
         /// </summary>
-        [EnumMember(Value = "Senate")]
-        Senate,
+        [EnumMember(Value = "I")]
+        Independent,
 
         /// <summary>
-        /// The United States House of Representatives
+        /// Republican Party. https://en.wikipedia.org/wiki/Republican_Party_(United_States)
         /// </summary>
-        [EnumMember(Value = "House")]
-        Representatives
+        [EnumMember(Value = "R")]
+        Republican,
+
+        /// <summary>
+        /// Democratic Party. https://en.wikipedia.org/wiki/Democratic_Party_(United_States)
+        /// </summary>
+        [EnumMember(Value = "D")]
+        Democratic
     }
 }

--- a/QuantConnect.DataSource.csproj
+++ b/QuantConnect.DataSource.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionDirectionJsonConverter.cs
+++ b/TransactionDirectionJsonConverter.cs
@@ -15,7 +15,6 @@
 
 using QuantConnect.Orders;
 using QuantConnect.Util;
-using System;
 
 namespace QuantConnect.DataSource
 {
@@ -41,23 +40,19 @@ namespace QuantConnect.DataSource
         /// <returns>Resulting OrderDirection</returns>
         protected override OrderDirection Convert(string value)
         {
-            switch (value.ToLowerInvariant())
+            value = value.ToLowerInvariant();
+
+            return value switch
             {
                 // Exchange transactions are transactions where one stock is
                 // exchanged for another. This could be the dumping of an asset,
                 // or the acquisition of an asset. Since we don't have enough
                 // data to disambiguiate which direction the transaction goes,
                 // let's return `OrderDirection.Hold` and filter those out.
-                case "purchase":
-                case "buy":
-                    return OrderDirection.Buy;
-                case "sale":
-                case "sell":
-                    return OrderDirection.Sell;
-                case "exchange":
-                default:
-                    return OrderDirection.Hold;
-            }
+                { } when value.StartsWith("purchase") || value.StartsWith("buy") => OrderDirection.Buy,
+                { } when value.StartsWith("sale") || value.StartsWith("sell") => OrderDirection.Sell,
+                _ => OrderDirection.Hold
+            };
         }
     }
 }


### PR DESCRIPTION
- Improve Data Source Classes 
  - Adds new available properties: Party, District, and State.
  - Fixes Transaction Direction Json converter to handle cases such as "Sale (Full)", since it was converted to `OrderDirection.Hold`.

- Updates Data Downloader 
  - Use the new endpoint `bulk/congresstrading?version=v2`.
  - Handle asset type to filter out non-stock
  - Handle trade size range that feeds the Amount and MaximumAmount properties.

- Adds and Updates Unit Tests