### PR TITLE
Incorporate `last_update`

### DIFF
--- a/QuiverCongressDataPoint.cs
+++ b/QuiverCongressDataPoint.cs
@@ -39,6 +39,16 @@ namespace QuantConnect.DataSource
         public static int DataSourceId { get; } = 2000;
 
         /// <summary>
+        /// The date the transaction was recorded by QuiverQuant. Value will always exist.
+        /// </summary>
+        public DateTime RecordDate { get; set; }
+
+        /// <summary>
+        /// The date the recorded transaction was updated by QuiverQuant. Alias for EndTime.
+        /// </summary>
+        public DateTime UpdatedAt => EndTime;
+
+        /// <summary>
         /// The date the transaction was reported. Value will always exist.
         /// </summary>
         [JsonProperty(PropertyName = "Filed")]
@@ -119,19 +129,20 @@ namespace QuantConnect.DataSource
         /// <param name="csvLine">CSV line</param>
         public QuiverCongressDataPoint(string csvLine)
         {
-            // Time[0], ReportDate[1], TransactionDate[2], Representative[3], Transaction[4],Amount[5],MaximumAmount[7],House[7],Party[8],District[9],State[10]
+            // Time[0], RecordDate[1], ReportDate[2], TransactionDate[3], Representative[4], Transaction[5],Amount[6],MaximumAmount[7],House[8],Party[9],District[10],State[11]
             var csv = csvLine.Split(',');
             Time = Parse.DateTimeExact(csv[0], "yyyyMMdd");
-            ReportDate = Parse.DateTimeExact(csv[1], "yyyyMMdd");
-            TransactionDate = Parse.DateTimeExact(csv[2], "yyyyMMdd");
-            Representative = csv[3].Replace(";",",");
-            Transaction = (OrderDirection)Enum.Parse(typeof(OrderDirection), csv[4], true);
-            Amount = csv[5].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
-            MaximumAmount = csv[6].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
-            House = (Congress)Enum.Parse(typeof(Congress), csv[7], true);
-            Party = (Party)Enum.Parse(typeof(Party), csv[8], true);
-            District = csv[9];
-            State = csv[10];
+            RecordDate = Parse.DateTimeExact(csv[1], "yyyyMMdd");
+            ReportDate = Parse.DateTimeExact(csv[2], "yyyyMMdd");
+            TransactionDate = Parse.DateTimeExact(csv[3], "yyyyMMdd");
+            Representative = csv[4].Replace(";",",");
+            Transaction = (OrderDirection)Enum.Parse(typeof(OrderDirection), csv[5], true);
+            Amount = csv[6].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
+            MaximumAmount = csv[7].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
+            House = (Congress)Enum.Parse(typeof(Congress), csv[8], true);
+            Party = (Party)Enum.Parse(typeof(Party), csv[9], true);
+            District = csv[10];
+            State = csv[11];
         }
 
         /// <summary>
@@ -163,6 +174,7 @@ namespace QuantConnect.DataSource
                 Symbol = Symbol,
                 Time = Time,
                 EndTime = EndTime,
+                RecordDate = RecordDate,
                 ReportDate = ReportDate,
                 TransactionDate = TransactionDate,
                 Representative = Representative,

--- a/QuiverQuantCongressUniverse.cs
+++ b/QuiverQuantCongressUniverse.cs
@@ -61,21 +61,22 @@ namespace QuantConnect.DataSource
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
             var csv = line.Split(',');
-            var amount = csv[6].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
-            var maximumAmount = csv[7].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
+            var amount = csv[7].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
+            var maximumAmount = csv[8].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
 
             return new QuiverQuantCongressUniverse
             {
-                ReportDate = Parse.DateTimeExact(csv[2], "yyyyMMdd"),
-                TransactionDate = Parse.DateTimeExact(csv[3], "yyyyMMdd"),
-                Representative = csv[4].Replace(";",","),
-                Transaction = (OrderDirection)Enum.Parse(typeof(OrderDirection), csv[5], true),
+                RecordDate = Parse.DateTimeExact(csv[2], "yyyyMMdd"),
+                ReportDate = Parse.DateTimeExact(csv[3], "yyyyMMdd"),
+                TransactionDate = Parse.DateTimeExact(csv[4], "yyyyMMdd"),
+                Representative = csv[5].Replace(";",","),
+                Transaction = (OrderDirection)Enum.Parse(typeof(OrderDirection), csv[6], true),
                 Amount = amount,
                 MaximumAmount = maximumAmount,
-                House = (Congress)Enum.Parse(typeof(Congress), csv[8], true),
-                Party = (Party)Enum.Parse(typeof(Party), csv[9], true),
-                District = csv[10],
-                State = csv[11],
+                House = (Congress)Enum.Parse(typeof(Congress), csv[9], true),
+                Party = (Party)Enum.Parse(typeof(Party), csv[10], true),
+                District = csv[11],
+                State = csv[12],
                 Symbol = new Symbol(SecurityIdentifier.Parse(csv[0]), csv[1]),
                 Value = amount ?? 0,
                 Time = date
@@ -112,6 +113,7 @@ namespace QuantConnect.DataSource
                 Symbol = Symbol,
                 Time = Time,
                 EndTime = EndTime,
+                RecordDate = RecordDate,
                 ReportDate = ReportDate,
                 TransactionDate = TransactionDate,
                 Representative = Representative,

--- a/tests/QuiverCongressTests.cs
+++ b/tests/QuiverCongressTests.cs
@@ -50,7 +50,7 @@ namespace QuantConnect.DataLibrary.Tests
         public void ReaderTest()
         {
             // This information is not factual and is only used for testing purposes
-            var content = "20230918,20230918,20230822,Gardner; Cory,Sell,15001,50000,Senate,Republican,,Alaska";
+            var content = "20230918,20230918,20230918,20230822,Gardner; Cory,Sell,15001,50000,Senate,Republican,,Alaska";
             var instance = CreateNewInstance();
             var config = new SubscriptionDataConfig(typeof(QuiverCongressDataPoint), _symbol, Resolution.Daily,
                 DateTimeZone.Utc, DateTimeZone.Utc, false, false, false);
@@ -64,7 +64,7 @@ namespace QuantConnect.DataLibrary.Tests
         {
             // This information is not factual and is only used for testing purposes
             var date = new DateTime(2023, 9, 18);
-            var content = "AAPL R735QTJ8XC9X,AAPL,20230918,20230822,Gardner; Cory,Sell,15001,50000,Senate,Republican,,Alaska";
+            var content = $"AAPL R735QTJ8XC9X,AAPL,{date:yyyyMMdd},20230918,20230822,Gardner; Cory,Sell,15001,50000,Senate,Republican,,Alaska";
             var instance = new QuiverQuantCongressUniverse();
             var config = new SubscriptionDataConfig(typeof(QuiverQuantCongressUniverse), Symbol.None, Resolution.Daily,
                 DateTimeZone.Utc, DateTimeZone.Utc, false, false, false);


### PR DESCRIPTION
`last_update` provides the last time the data was updated. It will be used as the timestamp (`EndTime`). An alias `UpdatedAt` for `EndTime` was added for convenience. Users can get the time the data was added/recorded with the `RecordDate` (`Quiver_Upload_Time` see #12) member.

Closes #13 