### PR TITLE
Fixes Trade Size Range

### DIFF
--- a/DataProcessing/QuiverCongressDataDownloader.cs
+++ b/DataProcessing/QuiverCongressDataDownloader.cs
@@ -367,8 +367,16 @@ namespace QuantConnect.DataProcessing
             /// </summary>
             public override string ToString()
             {
-                var isSingle = true;
+                var (min, max) = (double.MaxValue, double.MinValue);
                 var tradeSizeRange = new StringBuilder();
+                void setRange()
+                {
+                    var size = double.Parse(tradeSizeRange.ToString());
+                    min = Math.Min(min, size);
+                    max = Math.Max(max, size);
+                    tradeSizeRange.Clear();
+                }
+
                 foreach (var c in TradeSizeRange.AsSpan())
                 {
                     if (char.IsDigit(c))
@@ -377,15 +385,11 @@ namespace QuantConnect.DataProcessing
                     }
                     else if (c == '-')
                     {
-                        isSingle = false;
-                        tradeSizeRange.Append(',');
+                        setRange();
                     }
                 }
 
-                if (isSingle)
-                {
-                    tradeSizeRange.Append(',');
-                }
+                setRange();
 
                 return string.Join(",",
                         $"{UploadDate.ToStringInvariant("yyyyMMdd")}",
@@ -393,7 +397,7 @@ namespace QuantConnect.DataProcessing
                         $"{TransactionDate.ToStringInvariant("yyyyMMdd")}",
                         $"{Representative.Trim().Replace(",", ";")}",
                         $"{Transaction}",
-                        $"{tradeSizeRange}",
+                        min == max ? $"{min}," : $"{min},{max}",
                         $"{House}",
                         $"{Party}",
                         $"{District?.Trim()}",


### PR DESCRIPTION
In some cases, `Trade_Size_USD` has more than two values: "$250001 - $500000 - $100001". The data reader only accepts two values, so we will use the minium and the maximum:

Old:
```
CHKM UONN41X6723P,WPZ,20150303,20150303,20150202,David A. Trott,Buy,250001,500000,100001,Representatives,Republican,MI11,Michigan
```

New:
```
CHKM UONN41X6723P,WPZ,20150303,20150303,20150202,David A. Trott,Buy,100001,500000,Representatives,Republican,MI11,Michigan
```