### PR TITLE
Add Libertarian Party support and fix ticker sanitization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
             # Build Tests
             dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1 && \
             # Run Tests
-            dotnet test ./tests/bin/Release/net9.0/Tests.dll && \
+            dotnet test ./tests/bin/Release/net10.0/Tests.dll && \
             # Build Data Processing
             dotnet build ./DataProcessing/DataProcessing.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1

--- a/DataProcessing/QuiverCongressDataDownloader.cs
+++ b/DataProcessing/QuiverCongressDataDownloader.cs
@@ -194,6 +194,7 @@ namespace QuantConnect.DataProcessing
                                 .Replace("-DEFUNCT", string.Empty)
                                 .Replace(" ", string.Empty)
                                 .Replace("|", string.Empty)
+                                .Replace("/", ".")
                                 .Replace("-", ".");
                         
                         if (!congressTradesByTicker.TryGetValue(ticker, out var _))

--- a/Party.cs
+++ b/Party.cs
@@ -38,6 +38,12 @@ namespace QuantConnect.DataSource
         /// Democratic Party. https://en.wikipedia.org/wiki/Democratic_Party_(United_States)
         /// </summary>
         [EnumMember(Value = "D")]
-        Democratic
+        Democratic,
+
+        /// <summary>
+        /// Libertarian Party. https://en.wikipedia.org/wiki/Libertarian_Party_(United_States)
+        /// </summary>
+        [EnumMember(Value = "L")]
+        Libertarian
     }
 }

--- a/tests/QuiverCongressTests.cs
+++ b/tests/QuiverCongressTests.cs
@@ -83,6 +83,27 @@ namespace QuantConnect.DataLibrary.Tests
         }
 
         [Test]
+        public void DeserializeLibertarianPartyFromJson()
+        {
+            var content = "{ \"Ticker\": \"CVS\", \"TickerType\": \"Stock\",\"Company\": \"CVS Corp\",\"Traded\": \"2023-08-22\",\"Transaction\": \"Sale (Full)\",\"Trade_Size_USD\": \"$1,001 - $15,000\",\"Status\": \"New\",\"Subholding\": null,\"Description\": null,\"Name\": \"Chase, Oliver\",\"Filed\": \"2023-09-18\",\"Party\": \"Libertarian\",\"District\": null,\"Chamber\": \"Senate\",\"Comments\": null,\"excess_return\": \"5.894026562437\",\"State\": \"Alaska\"}";
+            var data = JsonConvert.DeserializeObject<QuiverCongressDataPoint>(content, _jsonSerializerSettings);
+
+            Assert.AreEqual(Party.Libertarian, data.Party);
+        }
+
+        [Test]
+        public void ReaderLibertarianPartyTest()
+        {
+            var content = "20230918,20230918,20230918,20230822,Chase; Oliver,Sell,15001,50000,Senate,Libertarian,,Alaska";
+            var instance = CreateNewInstance();
+            var config = new SubscriptionDataConfig(typeof(QuiverCongressDataPoint), _symbol, Resolution.Daily,
+                DateTimeZone.Utc, DateTimeZone.Utc, false, false, false);
+            var data = instance.Reader(config, content, DateTime.UtcNow, false) as QuiverCongressDataPoint;
+
+            Assert.AreEqual(Party.Libertarian, data.Party);
+        }
+
+        [Test]
         public void JsonRoundTrip()
         {
             var expected = CreateNewInstance();


### PR DESCRIPTION
## Summary
- Add `Libertarian` member to the `Party` enum to handle `"Libertarian"` values from the QuiverQuant API
- Sanitize `/` in tickers to prevent invalid file paths (e.g. `DUE12/01/27`)
- Add unit tests for Libertarian party deserialization (JSON and CSV)

## Test plan
- [x] Reproduced original `JsonSerializationException` by reverting fix
- [x] Verified DataProcessing runs successfully with fix (4,841 securities)
- [x] Confirmed Libertarian trades present in output (e.g. Justin Amash)
- [x] All 8 unit tests pass